### PR TITLE
Bugfixes/access fixes

### DIFF
--- a/ElasticSwift.xcodeproj/project.pbxproj
+++ b/ElasticSwift.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 /* Begin PBXBuildFile section */
 		062666F722CDA26200E32F15 /* IndicesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 062666F622CDA26200E32F15 /* IndicesResponse.swift */; };
 		062666F922CDFC7300E32F15 /* ResponseConverters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 062666F822CDFC7300E32F15 /* ResponseConverters.swift */; };
+		06DF10F222DA959A00B691A2 /* CodableUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06DF10F122DA959A00B691A2 /* CodableUtils.swift */; };
 		06E1332522D997D500C5230F /* SerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06E1332422D997D500C5230F /* SerializationTests.swift */; };
 		OBJ_1000 /* cipher.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_275 /* cipher.c */; };
 		OBJ_1001 /* e_aes.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_276 /* e_aes.c */; };
@@ -1226,6 +1227,7 @@
 /* Begin PBXFileReference section */
 		062666F622CDA26200E32F15 /* IndicesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndicesResponse.swift; sourceTree = "<group>"; };
 		062666F822CDFC7300E32F15 /* ResponseConverters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseConverters.swift; sourceTree = "<group>"; };
+		06DF10F122DA959A00B691A2 /* CodableUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableUtils.swift; sourceTree = "<group>"; };
 		06E1332422D997D500C5230F /* SerializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerializationTests.swift; sourceTree = "<group>"; };
 		"ElasticSwift::ElasticSwift::Product" /* ElasticSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ElasticSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"ElasticSwift::ElasticSwiftTests::Product" /* ElasticSwiftTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = ElasticSwiftTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -3046,6 +3048,7 @@
 			isa = PBXGroup;
 			children = (
 				OBJ_58 /* Utils.swift */,
+				06DF10F122DA959A00B691A2 /* CodableUtils.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -4470,6 +4473,7 @@
 				062666F722CDA26200E32F15 /* IndicesResponse.swift in Sources */,
 				OBJ_1341 /* MatchAllBuilders.swift in Sources */,
 				OBJ_1342 /* QueryBuilder.swift in Sources */,
+				06DF10F222DA959A00B691A2 /* CodableUtils.swift in Sources */,
 				OBJ_1343 /* QueryBuilders.swift in Sources */,
 				OBJ_1344 /* ScoreFunctionBuilders.swift in Sources */,
 				OBJ_1345 /* SpanQueryBuilders.swift in Sources */,

--- a/Sources/ElasticSwift/Errors/Errors.swift
+++ b/Sources/ElasticSwift/Errors/Errors.swift
@@ -12,15 +12,13 @@ import Foundation
 
 //MARK:- Elasticsearch Default Error
 
-public class ElasticsearchError: Error, Codable {
+public struct ElasticsearchError: Error, Codable {
     
-    var error: ElasticError?
-    var status: Int?
-    
-    init() {}
+    var error: ElasticError
+    var status: Int
 }
 
-public class ElasticError: Codable {
+public struct ElasticError: Codable {
     
     var type: String?
     var index: String?
@@ -28,8 +26,6 @@ public class ElasticError: Codable {
     var reason: String?
     var indexUUID: String?
     var rootCause: [ElasticError]?
-    
-    init() {}
     
     enum CodingKeys: String, CodingKey {
         case rootCause = "root_cause"
@@ -74,7 +70,7 @@ public class RequestConverterError<T: Request>: Error {
     
 }
 
-public class ResponseConverterError: Error {
+public class ResponseConverterError: Error, CustomStringConvertible, CustomDebugStringConvertible {
     
     public let error: Error
     public let message: String
@@ -84,6 +80,18 @@ public class ResponseConverterError: Error {
         self.error = error
         self.message = message
         self.response = response
+    }
+    
+    public var description: String {
+        get {
+            return "ResponseConverterError: \(message) Response: \(String(describing: response)) with Error: \(String(describing: error))"
+        }
+    }
+    
+    public var debugDescription: String {
+        get {
+            return "ResponseConverterError: \(message) Response: \(String(reflecting: response)) with Error: \(String(reflecting: error))"
+        }
     }
     
 }
@@ -162,13 +170,13 @@ public class DecodingError: Error, CustomStringConvertible, CustomDebugStringCon
     
     public var description: String {
         get {
-            return "DecodingError: Unable to decode \(self.type) from \(data.description) with Error: \(error.localizedDescription)"
+            return "DecodingError: Unable to decode \(String(describing: self.type)) from \(String(describing: self.data)) with Error: \(String(describing: self.error))"
         }
     }
     
     public var debugDescription: String {
         get {
-            return "DecodingError: Unable to decode \(self.type) from \(data.debugDescription) with Error: \(error.localizedDescription)"
+            return "DecodingError: Unable to decode \(self.type) from \(String(reflecting: self.data)) with Error: \(String(reflecting: self.error))"
         }
     }
     

--- a/Sources/ElasticSwift/Errors/Errors.swift
+++ b/Sources/ElasticSwift/Errors/Errors.swift
@@ -173,3 +173,8 @@ public class DecodingError: Error, CustomStringConvertible, CustomDebugStringCon
     }
     
 }
+
+
+public enum RequestBuilderError: Error {
+    case missingRequiredField(String)
+}

--- a/Sources/ElasticSwift/Networking/HTTPRequest.swift
+++ b/Sources/ElasticSwift/Networking/HTTPRequest.swift
@@ -55,7 +55,7 @@ public class HTTPRequest {
             if self.queryParams.isEmpty {
                 return ""
             } else {
-                return queryParams.map { $0.name + "=" + ($0.value ?? "") }.joined(separator: "&")
+                return "?" + queryParams.map { $0.name + "=" + ($0.value ?? "") }.joined(separator: "&")
             }
         }
     }

--- a/Sources/ElasticSwift/Queries/MatchAllQuery.swift
+++ b/Sources/ElasticSwift/Queries/MatchAllQuery.swift
@@ -17,7 +17,7 @@ public class MatchAllQuery: Query {
     
     public let boost: Decimal?
     
-    init(_ boost: Decimal? = nil) {
+    public init(_ boost: Decimal? = nil) {
         self.boost = boost
     }
     
@@ -40,7 +40,7 @@ public class MatchNoneQuery: Query {
     
     public let name: String = "match_none"
     
-    init() {}
+    public init() {}
     
     convenience init(withBuilder builder: MatchNoneQueryBuilder) {
         self.init()

--- a/Sources/ElasticSwift/Requests/DeleteRequest.swift
+++ b/Sources/ElasticSwift/Requests/DeleteRequest.swift
@@ -20,7 +20,9 @@ public class DeleteRequestBuilder: RequestBuilder {
     var index: String?
     var type: String?
     var id: String?
-    var version: Int?
+    var version: String?
+    var versionType: VersionType?
+    var refresh: IndexRefresh?
     
     init() {}
     
@@ -28,28 +30,53 @@ public class DeleteRequestBuilder: RequestBuilder {
         builderClosure(self)
     }
     
+    @discardableResult
     public func set(index: String) -> Self {
         self.index = index
         return self
     }
     
+    @discardableResult
     @available(*, deprecated, message: "Elasticsearch has deprecated use of custom types and will be remove in 7.0")
     public func set(type: String) -> Self {
         self.type = type
         return self
     }
     
+    @discardableResult
     public func set(id: String) -> Self {
         self.id = id
         return self
     }
     
-    public func set(version: Int) -> Self {
+    @discardableResult
+    public func set(version: String) -> Self {
         self.version = version
         return self
     }
     
+    @discardableResult
+    public func set(versionType: VersionType) -> Self {
+        self.versionType = versionType
+        return self
+    }
+    
+    @discardableResult
+    public func set(refresh: IndexRefresh) -> Self {
+        self.refresh = refresh
+        return self
+    }
+    
     public func build() throws -> RequestType {
+        
+        guard self.index != nil else {
+            throw RequestBuilderError.missingRequiredField("index")
+        }
+        
+        guard self.id != nil else {
+            throw RequestBuilderError.missingRequiredField("id")
+        }
+        
         return try DeleteRequest(withBuilder: self)
     }
     
@@ -61,27 +88,28 @@ public class DeleteRequest: Request {
     
     public var headers: HTTPHeaders = HTTPHeaders()
     
-    public var queryParams: [URLQueryItem] = []
-    
     public typealias ResponseType = DeleteResponse
     
-    let index: String
-    let type: String
-    let id: String
-    var version: Int?
+    public let index: String
+    public let type: String
+    public let id: String
+    public var version: String?
+    public var versionType: VersionType?
+    public var refresh: IndexRefresh?
     
-    public init(index: String, type: String, id: String, version: Int?) {
+    public init(index: String, type: String = "_doc", id: String) {
         self.index = index
         self.type = type
         self.id = id
-        self.version = version
     }
     
     init(withBuilder builder: DeleteRequestBuilder) throws {
         self.index = builder.index!
-        self.type = builder.type!
+        self.type = builder.type ?? "_doc"
         self.id = builder.id!
         self.version = builder.version
+        self.versionType = builder.versionType
+        self.refresh = builder.refresh
     }
     
     public var method: HTTPMethod {
@@ -92,12 +120,22 @@ public class DeleteRequest: Request {
     
     public var endPoint: String {
         get {
-            return makeEndPoint()
+            return self.index + "/" + self.type + "/" + self.id
         }
     }
     
-    func makeEndPoint() -> String {
-        return self.index + "/" + self.type + "/" + self.id
+    public var queryParams: [URLQueryItem] {
+        get {
+            var params = [URLQueryItem]()
+            if let version = self.version, let versionType = self.versionType {
+                params.append(URLQueryItem(name: QueryParams.version.rawValue, value: version))
+                params.append(URLQueryItem(name: QueryParams.versionType.rawValue, value: versionType.rawValue))
+            }
+            if let refresh = self.refresh {
+                params.append(URLQueryItem(name: QueryParams.refresh.rawValue, value: refresh.rawValue))
+            }
+            return params
+        }
     }
     
     public func makeBody(_ serializer: Serializer) -> Result<Data, MakeBodyError> {

--- a/Sources/ElasticSwift/Requests/GetRequest.swift
+++ b/Sources/ElasticSwift/Requests/GetRequest.swift
@@ -19,7 +19,6 @@ public class GetRequestBuilder<T: Codable>: RequestBuilder {
     var index: String?
     var type: String?
     var id: String?
-    var source: T?
     var method: HTTPMethod = .GET
     
     init() {}
@@ -28,23 +27,35 @@ public class GetRequestBuilder<T: Codable>: RequestBuilder {
         builderClosure(self)
     }
     
+    @discardableResult
     public func set(index: String) -> Self {
         self.index = index
         return self
     }
     
+    @discardableResult
     @available(*, deprecated, message: "Elasticsearch has deprecated use of custom types and will be remove in 7.0")
     public func set(type: String) -> Self {
         self.type = type
         return self
     }
     
+    @discardableResult
     public func set(id: String) -> Self {
         self.id = id
         return self
     }
     
     public func build() throws -> GetRequest<T> {
+        
+        guard self.index != nil else {
+            throw RequestBuilderError.missingRequiredField("index")
+        }
+        
+        guard self.id != nil else {
+            throw RequestBuilderError.missingRequiredField("id")
+        }
+        
         return try GetRequest<T>(withBuilder: self)
     }
     
@@ -62,9 +73,9 @@ public class GetRequest<T: Codable>: Request {
     
     public typealias ResponseType = GetResponse<T>
     
-    var index: String
-    var type: String
-    var id: String
+    public let index: String
+    public let type: String
+    public let id: String
     
     public var method: HTTPMethod {
         get {
@@ -72,7 +83,7 @@ public class GetRequest<T: Codable>: Request {
         }
     }
     
-    public init(index: String, type: String, id: String) {
+    public init(index: String, type: String = "_doc", id: String) {
         self.index = index
         self.type = type
         self.id = id
@@ -80,7 +91,7 @@ public class GetRequest<T: Codable>: Request {
     
     init(withBuilder builder: GetRequestBuilder<T>) throws {
         self.index = builder.index!
-        self.type = builder.type!
+        self.type = builder.type ?? "_doc"
         self.id =  builder.id!
     }
     

--- a/Sources/ElasticSwift/Requests/IndexRequest.swift
+++ b/Sources/ElasticSwift/Requests/IndexRequest.swift
@@ -22,6 +22,9 @@ public class IndexRequestBuilder<T: Codable>: RequestBuilder {
     var source: T?
     var routing: String?
     var parent: String?
+    var version: String?
+    var versionType: VersionType?
+    var refresh: IndexRefresh?
     
     init() {}
     
@@ -29,38 +32,75 @@ public class IndexRequestBuilder<T: Codable>: RequestBuilder {
         builderClosure(self)
     }
     
+    @discardableResult
     public func set(index: String) -> Self {
         self.index = index
         return self
     }
     
+    @discardableResult
     @available(*, deprecated, message: "Elasticsearch has deprecated use of custom types and will be remove in 7.0")
     public func set(type: String) -> Self {
         self.type = type
         return self
     }
     
+    @discardableResult
     public func set(id: String) -> Self {
         self.id = id
         return self
     }
     
+    @discardableResult
     public func set(routing: String) -> Self {
         self.routing = routing
         return self
     }
     
+    @discardableResult
     public func set(parent: String) -> Self {
         self.parent = parent
         return self
     }
     
+    @discardableResult
     public func set(source: T) -> Self {
         self.source = source
         return self
     }
     
+    @discardableResult
+    public func set(version: String) -> Self {
+        self.version = version
+        return self
+    }
+    
+    @discardableResult
+    public func set(versionType: VersionType) -> Self {
+        self.versionType = versionType
+        return self
+    }
+    
+    @discardableResult
+    public func set(refresh: IndexRefresh) -> Self {
+        self.refresh = refresh
+        return self
+    }
+    
     public func build() throws -> IndexRequest<T> {
+        
+        guard self.index != nil else {
+            throw RequestBuilderError.missingRequiredField("index")
+        }
+        
+        guard self.source != nil else {
+            throw RequestBuilderError.missingRequiredField("source")
+        }
+        
+        guard (self.version != nil && self.versionType != nil) || (self.version == nil && self.versionType == nil) else {
+            throw RequestBuilderError.missingRequiredField("source")
+        }
+        
         return try IndexRequest<T>(withBuilder: self)
     }
     
@@ -71,8 +111,6 @@ public class IndexRequestBuilder<T: Codable>: RequestBuilder {
 public class IndexRequest<T: Codable>: Request {
     
     public var headers: HTTPHeaders = HTTPHeaders()
-    
-    public var queryParams: [URLQueryItem] = []
     
     public typealias ResponseType = IndexResponse
     
@@ -85,34 +123,50 @@ public class IndexRequest<T: Codable>: Request {
         }
     }
     
-    var index: String
-    var type: String?
-    var id: String?
-    var source: T
-    var routing: String?
-    var parent: String?
+    public let index: String
+    public let type: String
+    public let id: String?
+    public let source: T
+    public var routing: String?
+    public var parent: String?
+    public var version: String?
+    public var versionType: VersionType?
+    public var refresh: IndexRefresh?
     
-    public init(index: String, type: String?, id: String?, source: T, routing: String?, parent: String?) {
+    public init(index: String, type: String = "_doc", id: String?, source: T) {
+        self.index = index
+        self.type = type
+        self.id = id
+        self.source = source
+    }
+    
+    public init(index: String, type: String = "_doc", id: String?, source: T, routing: String?, parent: String?, refresh: IndexRefresh?, version: String, versionType: VersionType) {
         self.index = index
         self.type = type
         self.id = id
         self.source = source
         self.routing = routing
         self.parent = parent
+        self.refresh = refresh
+        self.version = version
+        self.versionType = versionType
     }
     
-    convenience init(withBuilder builder: IndexRequestBuilder<T>) throws {
-        
-        self.init(index: builder.index!, type: builder.type, id: builder.id, source: builder.source!, routing: builder.routing, parent: builder.parent)
-
+    init(withBuilder builder: IndexRequestBuilder<T>) throws {
+        self.index = builder.index!
+        self.id = builder.id
+        self.type = builder.type ?? "_doc"
+        self.source = builder.source!
+        self.routing = builder.routing
+        self.parent = builder.parent
+        self.version = builder.version
+        self.versionType = builder.versionType
+        self.refresh = builder.refresh
     }
     
     public var endPoint: String {
         get {
-            var _endPoint = self.index
-            if let type = self.type {
-                _endPoint = _endPoint + "/" + type
-            }
+            var _endPoint = self.index + "/" + type
             if let id = self.id {
                 _endPoint = _endPoint + "/" + id
             }
@@ -124,11 +178,25 @@ public class IndexRequest<T: Codable>: Request {
         return serializer.encode(self.source).flatMapError { error in return .failure(.wrapped(error)) }
     }
     
-}
-
-
-enum OpType {
-    case INDEX
-    case CREATE
+    public var queryParams: [URLQueryItem] {
+        get {
+            var queryItems = [URLQueryItem]()
+            if let routing = self.routing {
+                queryItems.append(URLQueryItem(name: QueryParams.routing.rawValue, value: routing))
+            }
+            if let version = self.version, let versionType = self.versionType {
+                queryItems.append(URLQueryItem(name: QueryParams.version.rawValue, value: version))
+                queryItems.append(URLQueryItem(name: QueryParams.versionType.rawValue, value: versionType.rawValue))
+            }
+            if let refresh = self.refresh {
+                queryItems.append(URLQueryItem(name: QueryParams.refresh.rawValue, value: refresh.rawValue))
+            }
+            if let parentId = self.parent {
+                queryItems.append(URLQueryItem(name: QueryParams.parent.rawValue, value: parentId))
+            }
+            return queryItems
+        }
+    }
+    
 }
 

--- a/Sources/ElasticSwift/Requests/SearchRequest.swift
+++ b/Sources/ElasticSwift/Requests/SearchRequest.swift
@@ -94,22 +94,22 @@ public class SearchRequest<T: Codable>: Request {
     
     public typealias ResponseType = SearchResponse<T>
     
-    var index: String?
-    var type: String?
-    var from: Int16?
-    var size: Int16?
-    var query: Query?
-    var sort: Sort?
-    var fetchSource: Bool?
-    var explain: Bool?
-    var minScore: Decimal?
+    public let index: String
+    public let type: String?
+    public let from: Int16?
+    public let size: Int16?
+    public let query: Query?
+    public let sort: Sort?
+    public let fetchSource: Bool?
+    public let explain: Bool?
+    public let minScore: Decimal?
     
     init(withBuilder builder: SearchRequestBuilder<T>) throws {
-        self.index = builder.index
+        self.index = builder.index ?? "_all"
         self.type = builder.type
+        self.query = builder.query
         self.from = builder.from
         self.size = builder.size
-        self.query = builder.query
         self.sort = builder.sort
         self.fetchSource = builder.fetchSource
         self.explain = builder.explain
@@ -124,20 +124,12 @@ public class SearchRequest<T: Codable>: Request {
     
     public var endPoint: String {
         get {
-            return makeEndPoint()
+            var path = self.index
+            if let type = self.type {
+                path += "/" + type
+            }
+            return  path + "/_search"
         }
-    }
-    
-    func makeEndPoint() -> String {
-        var path: String = ""
-        if let index = self.index {
-            path += index + "/"
-        }
-        if let type = self.type {
-            path += type + "/"
-        }
-        path += "_search"
-        return path
     }
     
     public func makeBody(_ serializer: Serializer) -> Result<Data, MakeBodyError> {

--- a/Sources/ElasticSwift/Responses/Response.swift
+++ b/Sources/ElasticSwift/Responses/Response.swift
@@ -31,7 +31,7 @@ public struct GetResponse<T: Codable>: Codable {
     public let version: Int?
     public let found: Bool
     public let source: T?
-    public let seqNo: Int?
+    public let seqNumber: Int?
     public let primaryTerm: Int?
     
     enum CodingKeys: String, CodingKey {
@@ -41,7 +41,7 @@ public struct GetResponse<T: Codable>: Codable {
         case version = "_version"
         case source = "_source"
         case found
-        case seqNo = "_seq_no"
+        case seqNumber = "_seq_no"
         case primaryTerm = "_primary_term"
     }
 }

--- a/Sources/ElasticSwift/Responses/Response.swift
+++ b/Sources/ElasticSwift/Responses/Response.swift
@@ -134,14 +134,14 @@ public struct SearchHit<T: Codable>: Codable {
 
 public struct DeleteResponse: Codable {
     
-    public let shards: Shards?
-    public let index: String?
-    public let type: String?
-    public let id: String?
-    public let version: Int?
-    public let seqNumber: Int?
-    public let primaryTerm: Int?
-    public let result: String?
+    public let shards: Shards
+    public let index: String
+    public let type: String
+    public let id: String
+    public let version: Int
+    public let seqNumber: Int
+    public let primaryTerm: Int
+    public let result: String
     
     enum CodingKeys: String, CodingKey {
         case shards = "_shards"

--- a/Sources/ElasticSwift/Responses/Response.swift
+++ b/Sources/ElasticSwift/Responses/Response.swift
@@ -73,16 +73,12 @@ public struct IndexResponse: Codable {
 
 //MARK:- Search Response
 
-public class SearchResponse<T: Codable>: Codable {
+public struct SearchResponse<T: Codable>: Codable {
     
-    public var took: Int?
-    public var timedOut: Bool?
-    public var shards: Shards?
-    public var hits: Hits<T>?
-    
-    init() {
-        
-    }
+    public let took: Int
+    public let timedOut: Bool
+    public let shards: Shards
+    public let hits: Hits<T>
     
     enum CodingKeys: String, CodingKey {
         case took
@@ -94,23 +90,19 @@ public class SearchResponse<T: Codable>: Codable {
 
 public struct Shards: Codable {
     
-    public var total: Int
-    public var successful: Int
-    public var skipped: Int?
-    public var failed: Int
+    public let total: Int
+    public let successful: Int
+    public let skipped: Int?
+    public let failed: Int
     
 }
 
 
-public class Hits<T: Codable>: Codable {
+public struct Hits<T: Codable>: Codable {
     
-    public var total: Int?
-    public var maxScore: Decimal?
-    public var hits: [SearchHit<T>] = []
-    
-    init() {
-        
-    }
+    public let total: Int
+    public let maxScore: Decimal?
+    public let hits: [SearchHit<T>] = []
     
     enum CodingKeys: String, CodingKey {
         case total
@@ -121,18 +113,13 @@ public class Hits<T: Codable>: Codable {
 }
 
 
-public class SearchHit<T: Codable>: Codable {
+public struct SearchHit<T: Codable>: Codable {
     
-    public var index: String?
-    public var type: String?
-    public var id: String?
-    public var score: Decimal?
-    public var source: T?
-    
-    
-    init() {
-        
-    }
+    public let index: String
+    public let type: String
+    public let id: String
+    public let score: Decimal
+    public let source: T?
     
     enum CodingKeys: String, CodingKey {
         case index = "_index"

--- a/Sources/ElasticSwift/Responses/Response.swift
+++ b/Sources/ElasticSwift/Responses/Response.swift
@@ -23,19 +23,16 @@ public class ESResponse {
 
 //MARK:- Get Response
 
-public class GetResponse<T: Codable>: Codable {
+public struct GetResponse<T: Codable>: Codable {
     
-    public var index: String?
-    public var type: String?
-    public var id: String?
-    public var version: Int?
-    public var found: Bool?
-    
-    public var source: T?
-    
-    init() {
-        
-    }
+    public let index: String
+    public let type: String
+    public let id: String
+    public let version: Int?
+    public let found: Bool
+    public let source: T?
+    public let seqNo: Int?
+    public let primaryTerm: Int?
     
     enum CodingKeys: String, CodingKey {
         case index = "_index"
@@ -43,8 +40,9 @@ public class GetResponse<T: Codable>: Codable {
         case id = "_id"
         case version = "_version"
         case source = "_source"
-        
         case found
+        case seqNo = "_seq_no"
+        case primaryTerm = "_primary_term"
     }
 }
 

--- a/Sources/ElasticSwift/Responses/Response.swift
+++ b/Sources/ElasticSwift/Responses/Response.swift
@@ -48,20 +48,16 @@ public struct GetResponse<T: Codable>: Codable {
 
 //MARK:- Index Response
 
-public class IndexResponse: Codable {
+public struct IndexResponse: Codable {
     
-    public var shards: Shards?
-    public var index: String?
-    public var type: String?
-    public var id: String?
-    public var version: Int?
-    public var seqNumber: Int?
-    public var primaryTerm: Int?
-    public var result: String?
-    
-    init() {
-        
-    }
+    public let shards: Shards
+    public let index: String
+    public let type: String
+    public let id: String
+    public let version: Int
+    public let seqNumber: Int
+    public let primaryTerm: Int
+    public let result: String
     
     enum CodingKeys: String, CodingKey {
         case shards = "_shards"
@@ -96,16 +92,12 @@ public class SearchResponse<T: Codable>: Codable {
     }
 }
 
-public class Shards: Codable {
+public struct Shards: Codable {
     
-    public var total: Int?
-    public var successful: Int?
+    public var total: Int
+    public var successful: Int
     public var skipped: Int?
-    public var failed: Int?
-    
-    init() {
-        
-    }
+    public var failed: Int
     
 }
 

--- a/Sources/ElasticSwift/Serialization/ResponseConverters.swift
+++ b/Sources/ElasticSwift/Serialization/ResponseConverters.swift
@@ -26,6 +26,18 @@ public class ResponseConverters {
                 if var body = response.body, let bytes = body.readBytes(length: body.readableBytes) {
                     let data = Data(bytes)
                     guard (!response.status.isError()) else {
+                        
+                        /// handle GetResponse 404
+                        if response.status == .notFound {
+                            let decodedResponse: Result<T, DecodingError> = serializer.decode(data: data)
+                            switch decodedResponse {
+                            case .success(let result):
+                                return callback(.success(result))
+                            default:
+                                break;
+                            }
+                        }
+                        
                         let decodedError: Result<ElasticsearchError, DecodingError> = serializer.decode(data: data)
                         switch decodedError {
                         case .failure(let error):

--- a/Sources/ElasticSwift/Utils/CodableUtils.swift
+++ b/Sources/ElasticSwift/Utils/CodableUtils.swift
@@ -1,0 +1,478 @@
+//
+//  CodableUtils.swift
+//  ElasticSwift
+//
+//  Created by Prafull Kumar Soni on 7/13/19.
+//
+
+import Foundation
+
+//MARK:- CodableValue
+
+public protocol CodableWrapper: Codable {
+    
+    var value: Codable { get }
+    
+    init<T>(_ value: T) where T: Codable
+    
+}
+
+extension CodableWrapper {
+    
+    public func encode(to encoder: Encoder) throws {
+        try value.encode(to: encoder)
+    }
+}
+
+extension CodableWrapper {
+    
+    public init(nilLiteral: ()) {
+        self.init([String: String]())
+    }
+    
+    public init(booleanLiteral value: Bool) {
+        self.init(value)
+    }
+    
+    public init(integerLiteral value: Int) {
+        self.init(value)
+    }
+    
+    public init(floatLiteral value: Double) {
+        self.init(value)
+    }
+    
+    public init(stringLiteral value: String) {
+        self.init(value)
+    }
+    
+    public init(extendedGraphemeClusterLiteral value: String) {
+        self.init(value)
+    }
+}
+
+/// Wrapper for `Codable` values similar to `AnyCodable` where value always conforms to `Codable`
+public final class CodableValue: CodableWrapper {
+    
+    public let value: Codable
+    
+    public init<T>(_ value: T) where T: Codable {
+        self.value = value
+    }
+    
+    public convenience init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        
+        if container.decodeNil() {
+            self.init(nilLiteral: ())
+        } else if let bool = try? container.decode(Bool.self) {
+            self.init(bool)
+        } else if let int = try? container.decode(Int.self) {
+            self.init(int)
+        } else if let uint = try? container.decode(UInt.self) {
+            self.init(uint)
+        } else if let double = try? container.decode(Double.self) {
+            self.init(double)
+        } else if let string = try? container.decode(String.self) {
+            self.init(string)
+        } else if let array = try? container.decode([CodableValue].self) {
+            self.init(array)
+        } else if let dictionary = try? container.decode([String: CodableValue].self) {
+            self.init(dictionary)
+        } else {
+            throw Swift.DecodingError.dataCorruptedError(in: container, debugDescription: "CodableValue cannot be decoded")
+        }
+    }
+}
+
+extension CodableValue: ExpressibleByNilLiteral {}
+extension CodableValue: ExpressibleByBooleanLiteral {}
+extension CodableValue: ExpressibleByIntegerLiteral {}
+extension CodableValue: ExpressibleByFloatLiteral {}
+extension CodableValue: ExpressibleByStringLiteral {}
+extension CodableValue: ExpressibleByExtendedGraphemeClusterLiteral {}
+extension CodableValue: ExpressibleByArrayLiteral {
+    public typealias ArrayLiteralElement = CodableValue
+    
+    public convenience init(arrayLiteral elements: CodableValue...)  {
+        self.init(elements)
+    }
+}
+extension CodableValue: ExpressibleByDictionaryLiteral {
+    public typealias Key = String
+    
+    public typealias Value = CodableValue
+    
+    
+    public convenience init(dictionaryLiteral elements: (String, CodableValue)...) {
+        self.init([String: CodableValue](elements, uniquingKeysWith: { first, _ in first }))
+    }
+}
+
+
+extension CodableValue: CustomStringConvertible {
+    public var description: String {
+        get {
+            if let value = self.value as? CustomStringConvertible {
+                return value.description
+            }
+            return "\(value)"
+        }
+    }
+}
+
+extension CodableValue: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        get {
+            if let value = self.value as? CustomDebugStringConvertible {
+                return value.debugDescription
+            }
+            return self.description
+        }
+    }
+}
+
+extension CodableValue: Equatable {
+    
+    public static func == (lhs: CodableValue, rhs: CodableValue) -> Bool {
+        switch (lhs.value, rhs.value) {
+        case let (lhs as Bool, rhs as Bool):
+            return lhs == rhs
+        case let (lhs as Int, rhs as Int):
+            return lhs == rhs
+        case let (lhs as Int8, rhs as Int8):
+            return lhs == rhs
+        case let (lhs as Int16, rhs as Int16):
+            return lhs == rhs
+        case let (lhs as Int32, rhs as Int32):
+            return lhs == rhs
+        case let (lhs as Int64, rhs as Int64):
+            return lhs == rhs
+        case let (lhs as UInt, rhs as UInt):
+            return lhs == rhs
+        case let (lhs as UInt8, rhs as UInt8):
+            return lhs == rhs
+        case let (lhs as UInt16, rhs as UInt16):
+            return lhs == rhs
+        case let (lhs as UInt32, rhs as UInt32):
+            return lhs == rhs
+        case let (lhs as UInt64, rhs as UInt64):
+            return lhs == rhs
+        case let (lhs as Float, rhs as Float):
+            return lhs == rhs
+        case let (lhs as Double, rhs as Double):
+            return lhs == rhs
+        case let (lhs as String, rhs as String):
+            return lhs == rhs
+        case let (lhs as [String: CodableValue], rhs as [String: CodableValue]):
+            return lhs == rhs
+        case let (lhs as [CodableValue], rhs as [CodableValue]):
+            return lhs == rhs
+        default:
+            return false
+        }
+    }
+}
+
+
+//MARK:- DecodableValue
+
+public protocol DecodableWrapper: Decodable {
+    
+    var value: Decodable { get }
+    
+    init<T>(_ value: T) where T: Decodable
+    
+}
+
+extension DecodableWrapper {
+    public init(nilLiteral: ()) {
+        self.init([String: String]())
+    }
+    
+    public init(booleanLiteral value: Bool) {
+        self.init(value)
+    }
+    
+    public init(integerLiteral value: Int) {
+        self.init(value)
+    }
+    
+    public init(floatLiteral value: Double) {
+        self.init(value)
+    }
+    
+    public init(stringLiteral value: String) {
+        self.init(value)
+    }
+    
+    public init(extendedGraphemeClusterLiteral value: String) {
+        self.init(value)
+    }
+}
+
+/// Wrapper for `Decodable` values similar to `AnyDecodable` where value always conforms to `Decodable`
+public final class DecodableValue: DecodableWrapper {
+    
+    public let value: Decodable
+    
+    public init<T>(_ value: T) where T: Decodable {
+        self.value = value
+    }
+    
+    public convenience init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        
+        if container.decodeNil() {
+            self.init(nilLiteral: ())
+        } else if let bool = try? container.decode(Bool.self) {
+            self.init(bool)
+        } else if let int = try? container.decode(Int.self) {
+            self.init(int)
+        } else if let uint = try? container.decode(UInt.self) {
+            self.init(uint)
+        } else if let double = try? container.decode(Double.self) {
+            self.init(double)
+        } else if let string = try? container.decode(String.self) {
+            self.init(string)
+        } else if let array = try? container.decode([DecodableValue].self) {
+            self.init(array)
+        } else if let dictionary = try? container.decode([String: DecodableValue].self) {
+            self.init(dictionary)
+        } else {
+            throw Swift.DecodingError.dataCorruptedError(in: container, debugDescription: "CodableValue cannot be decoded")
+        }
+    }
+}
+
+extension DecodableValue: ExpressibleByNilLiteral {}
+extension DecodableValue: ExpressibleByBooleanLiteral {}
+extension DecodableValue: ExpressibleByIntegerLiteral {}
+extension DecodableValue: ExpressibleByFloatLiteral {}
+extension DecodableValue: ExpressibleByStringLiteral {}
+extension DecodableValue: ExpressibleByExtendedGraphemeClusterLiteral {}
+extension DecodableValue: ExpressibleByArrayLiteral {
+    public typealias ArrayLiteralElement = DecodableValue
+    
+    public convenience init(arrayLiteral elements: DecodableValue...)  {
+        self.init(elements)
+    }
+}
+extension DecodableValue: ExpressibleByDictionaryLiteral {
+    public typealias Key = String
+    
+    public typealias Value = DecodableValue
+    
+    
+    public convenience init(dictionaryLiteral elements: (String, DecodableValue)...) {
+        self.init([String: DecodableValue](elements, uniquingKeysWith: { first, _ in first }))
+    }
+}
+
+extension DecodableValue: CustomStringConvertible {
+    public var description: String {
+        get {
+            if let value = self.value as? CustomStringConvertible {
+                return value.description
+            }
+            return "\(value)"
+        }
+    }
+}
+
+extension DecodableValue: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        get {
+            if let value = self.value as? CustomDebugStringConvertible {
+                return value.debugDescription
+            }
+            return self.description
+        }
+    }
+}
+
+extension DecodableValue: Equatable {
+    
+    public static func == (lhs: DecodableValue, rhs: DecodableValue) -> Bool {
+        switch (lhs.value, rhs.value) {
+        case let (lhs as Bool, rhs as Bool):
+            return lhs == rhs
+        case let (lhs as Int, rhs as Int):
+            return lhs == rhs
+        case let (lhs as Int8, rhs as Int8):
+            return lhs == rhs
+        case let (lhs as Int16, rhs as Int16):
+            return lhs == rhs
+        case let (lhs as Int32, rhs as Int32):
+            return lhs == rhs
+        case let (lhs as Int64, rhs as Int64):
+            return lhs == rhs
+        case let (lhs as UInt, rhs as UInt):
+            return lhs == rhs
+        case let (lhs as UInt8, rhs as UInt8):
+            return lhs == rhs
+        case let (lhs as UInt16, rhs as UInt16):
+            return lhs == rhs
+        case let (lhs as UInt32, rhs as UInt32):
+            return lhs == rhs
+        case let (lhs as UInt64, rhs as UInt64):
+            return lhs == rhs
+        case let (lhs as Float, rhs as Float):
+            return lhs == rhs
+        case let (lhs as Double, rhs as Double):
+            return lhs == rhs
+        case let (lhs as String, rhs as String):
+            return lhs == rhs
+        case let (lhs as [String: DecodableValue], rhs as [String: DecodableValue]):
+            return lhs == rhs
+        case let (lhs as [DecodableValue], rhs as [DecodableValue]):
+            return lhs == rhs
+        default:
+            return false
+        }
+    }
+}
+
+//MARK:- EncodableValue
+
+public protocol EncodableWrapper: Encodable {
+    
+    var value: Encodable { get }
+    
+    init<T>(_ value: T) where T: Encodable
+    
+}
+
+extension EncodableWrapper {
+    public func encode(to encoder: Encoder) throws {
+        try value.encode(to: encoder)
+    }
+}
+
+extension EncodableWrapper {
+    
+    public init(nilLiteral: ()) {
+        self.init([String: String]())
+    }
+    
+    public init(booleanLiteral value: Bool) {
+        self.init(value)
+    }
+    
+    public init(integerLiteral value: Int) {
+        self.init(value)
+    }
+    
+    public init(floatLiteral value: Double) {
+        self.init(value)
+    }
+    
+    public init(stringLiteral value: String) {
+        self.init(value)
+    }
+    
+    public init(extendedGraphemeClusterLiteral value: String) {
+        self.init(value)
+    }
+    
+}
+
+/// Wrapper for `Decodable` values similar to `AnyDecodable` where value always conforms to `Decodable`
+public final class EncodableValue: EncodableWrapper {
+    
+    public let value: Encodable
+    
+    public init<T>(_ value: T) where T: Encodable {
+        self.value = value
+    }
+}
+
+extension EncodableValue: ExpressibleByNilLiteral {}
+extension EncodableValue: ExpressibleByBooleanLiteral {}
+extension EncodableValue: ExpressibleByIntegerLiteral {}
+extension EncodableValue: ExpressibleByFloatLiteral {}
+extension EncodableValue: ExpressibleByStringLiteral {}
+extension EncodableValue: ExpressibleByExtendedGraphemeClusterLiteral {}
+
+extension EncodableValue: ExpressibleByArrayLiteral {
+    public typealias ArrayLiteralElement = EncodableValue
+    
+    public convenience init(arrayLiteral elements: EncodableValue...)  {
+        self.init(elements)
+    }
+}
+
+extension EncodableValue: ExpressibleByDictionaryLiteral {
+    public typealias Key = String
+    
+    public typealias Value = EncodableValue
+    
+    
+    public convenience init(dictionaryLiteral elements: (String, EncodableValue)...) {
+        self.init([String: EncodableValue](elements, uniquingKeysWith: { first, _ in first }))
+    }
+}
+
+extension EncodableValue: CustomStringConvertible {
+    public var description: String {
+        get {
+            if let value = self.value as? CustomStringConvertible {
+                return value.description
+            }
+            return "\(value)"
+        }
+    }
+}
+
+extension EncodableValue: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        get {
+            if let value = self.value as? CustomDebugStringConvertible {
+                return value.debugDescription
+            }
+            return self.description
+        }
+    }
+}
+
+extension EncodableValue: Equatable {
+    
+    public static func == (lhs: EncodableValue, rhs: EncodableValue) -> Bool {
+        switch (lhs.value, rhs.value) {
+        case let (lhs as Bool, rhs as Bool):
+            return lhs == rhs
+        case let (lhs as Int, rhs as Int):
+            return lhs == rhs
+        case let (lhs as Int8, rhs as Int8):
+            return lhs == rhs
+        case let (lhs as Int16, rhs as Int16):
+            return lhs == rhs
+        case let (lhs as Int32, rhs as Int32):
+            return lhs == rhs
+        case let (lhs as Int64, rhs as Int64):
+            return lhs == rhs
+        case let (lhs as UInt, rhs as UInt):
+            return lhs == rhs
+        case let (lhs as UInt8, rhs as UInt8):
+            return lhs == rhs
+        case let (lhs as UInt16, rhs as UInt16):
+            return lhs == rhs
+        case let (lhs as UInt32, rhs as UInt32):
+            return lhs == rhs
+        case let (lhs as UInt64, rhs as UInt64):
+            return lhs == rhs
+        case let (lhs as Float, rhs as Float):
+            return lhs == rhs
+        case let (lhs as Double, rhs as Double):
+            return lhs == rhs
+        case let (lhs as String, rhs as String):
+            return lhs == rhs
+        case let (lhs as [String: EncodableValue], rhs as [String: EncodableValue]):
+            return lhs == rhs
+        case let (lhs as [EncodableValue], rhs as [EncodableValue]):
+            return lhs == rhs
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/ElasticSwift/Utils/Utils.swift
+++ b/Sources/ElasticSwift/Utils/Utils.swift
@@ -27,6 +27,9 @@ enum QueryParams: String {
     case detailed = "detailed"
     case nodeId = "node_id"
     case parentNode = "parent_node"
+    case version
+    case versionType = "version_type"
+    case refresh
     case parentTask = "parent_task"
 }
 
@@ -111,4 +114,17 @@ public enum BoostMode: String {
     case AVG = "avg"
     case MIN = "min"
     case MAX = "max"
+}
+
+public enum VersionType: String {
+    case `internal`
+    case external
+    case externalGte = "external_gte"
+    case force
+}
+
+public enum IndexRefresh: String {
+    case `true`
+    case `false`
+    case waitFor = "wait_for"
 }

--- a/Sources/ElasticSwift/Utils/Utils.swift
+++ b/Sources/ElasticSwift/Utils/Utils.swift
@@ -39,6 +39,7 @@ enum QueryParams: String {
     case ifPrimaryTerm = "if_primary_term"
     case pipeline
     case includeTypeName = "include_type_name"
+    case parent
 }
 
 enum EndPointCategory: String {
@@ -135,4 +136,9 @@ public enum IndexRefresh: String {
     case `true`
     case `false`
     case waitFor = "wait_for"
+}
+
+public enum OpType: String {
+    case index
+    case create
 }

--- a/Sources/ElasticSwift/Utils/Utils.swift
+++ b/Sources/ElasticSwift/Utils/Utils.swift
@@ -9,28 +9,36 @@
 import Foundation
 
 enum QueryParams: String {
-    case format = "format"
-    case h = "h"
-    case help = "help"
-    case local = "local"
+    case format
+    case h
+    case help
+    case local
     case masterTimeout = "master_timeout"
-    case s = "s"
-    case v = "v"
-    case ts = "ts"
-    case bytes = "bytes"
-    case health = "health"
-    case pri = "pri"
+    case s
+    case v
+    case ts
+    case bytes
+    case health
+    case pri
     case fullId = "full_id"
-    case size = "size"
+    case size
     case ignoreUnavailable = "ignore_unavailable"
-    case actions = "actions"
-    case detailed = "detailed"
+    case actions
+    case detailed
     case nodeId = "node_id"
     case parentNode = "parent_node"
     case version
     case versionType = "version_type"
     case refresh
     case parentTask = "parent_task"
+    case waitForActiveShards = "wait_for_active_shards"
+    case opType = "op_type"
+    case routing
+    case timeout
+    case ifSeqNo = "if_seq_no"
+    case ifPrimaryTerm = "if_primary_term"
+    case pipeline
+    case includeTypeName = "include_type_name"
 }
 
 enum EndPointCategory: String {

--- a/Tests/ElasticSwiftTests/ElasticSwiftTests.swift
+++ b/Tests/ElasticSwiftTests/ElasticSwiftTests.swift
@@ -227,10 +227,10 @@ class ElasticSwiftTests: XCTestCase {
                 XCTAssert(false, error.localizedDescription)
             case .success(let response):
                 print("Respone", response)
-                XCTAssert(response.result == "deleted", "Result: \(response.result!)")
-                XCTAssert(response.id == "0", "_id: \(response.id!)")
-                XCTAssert(response.index == "test", "index: \(response.index!)")
-                XCTAssert(response.type == "_doc", "Type: \(response.type!)")
+                XCTAssert(response.result == "deleted", "Result: \(response.result)")
+                XCTAssert(response.id == "0", "_id: \(response.id)")
+                XCTAssert(response.index == "test", "index: \(response.index)")
+                XCTAssert(response.type == "_doc", "Type: \(response.type)")
             }
             e.fulfill()
         }

--- a/Tests/ElasticSwiftTests/ElasticSwiftTests.swift
+++ b/Tests/ElasticSwiftTests/ElasticSwiftTests.swift
@@ -169,14 +169,14 @@ class ElasticSwiftTests: XCTestCase {
             
             switch result {
             case .failure(let error):
-                print("Error: ", error)
-                XCTAssert(false, error.localizedDescription)
+                print("Error: ", String(reflecting: error))
+                XCTAssert(false, String(reflecting: error))
             case .success(let response):
                 print("Response: ", response)
-                XCTAssert(response.found!, "Found: \(response.found!)")
-                XCTAssert(response.index! == "test", "Index: \(response.index!)")
-                XCTAssert(response.id! == "0", "_id: \(response.id!)")
-                XCTAssert(response.type! == "_doc", "Found: \(response.type!)")
+                XCTAssert(response.found, "Found: \(response.found)")
+                XCTAssert(response.index == "test", "Index: \(response.index)")
+                XCTAssert(response.id == "0", "_id: \(response.id)")
+                XCTAssert(response.type == "_doc", "Found: \(response.type)")
             }
             e.fulfill()
         }

--- a/Tests/ElasticSwiftTests/ElasticSwiftTests.swift
+++ b/Tests/ElasticSwiftTests/ElasticSwiftTests.swift
@@ -110,10 +110,10 @@ class ElasticSwiftTests: XCTestCase {
                 XCTAssert(false, error.localizedDescription)
             case .success(let response):
                 print("Response: ", response)
-                XCTAssert(response.index == "test", "Index: \(response.index!)")
-                XCTAssert(response.id == "0", "_id \(response.id!)")
-                XCTAssert(response.type == "_doc", "Type: \(response.type!)")
-                XCTAssert(response.result != nil, "Resule: \(response.result!)")
+                XCTAssert(response.index == "test", "Index: \(response.index)")
+                XCTAssert(response.id == "0", "_id \(response.id)")
+                XCTAssert(response.type == "_doc", "Type: \(response.type)")
+                XCTAssert(!response.result.isEmpty, "Resule: \(response.result)")
             }
             e.fulfill()
         }
@@ -142,9 +142,9 @@ class ElasticSwiftTests: XCTestCase {
                 XCTAssert(false, error.localizedDescription)
             case .success(let response):
                 print("Response: ", response)
-                XCTAssert(response.index == "test", "Index: \(response.index!)")
-                XCTAssert(response.type == "_doc", "Type: \(response.type!)")
-                XCTAssert(response.result != nil, "Resule: \(response.result!)")
+                XCTAssert(response.index == "test", "Index: \(response.index)")
+                XCTAssert(response.type == "_doc", "Type: \(response.type)")
+                XCTAssert(!response.result.isEmpty, "Resule: \(response.result)")
             }
             e.fulfill()
         }
@@ -197,7 +197,7 @@ class ElasticSwiftTests: XCTestCase {
             case .failure(let error):
                 print("Error", error)
             case .success(let response):
-                print("Found", response.result!)
+                print("Found", response.result)
             }
             client?.execute(request: request, completionHandler: handler)
         }
@@ -247,7 +247,7 @@ class ElasticSwiftTests: XCTestCase {
             case .failure(let error):
                 print("Error: ", error)
             case .success(let response):
-                print("Result", response.result!)
+                print("Result", response.result)
             }
             
             self.client?.execute(request: request, completionHandler: handler)


### PR DESCRIPTION
* Fixes access for Request(s)/RequestBuilder(s) (members and initializers)
* Fixes remove unnecessary `?` optional for values that will always be present.
* Fixes to response serializations.
* QueryParams support for some requests to avoid unnecessary usage of `RequestOptions`.
* Support index `settings`, `mappings` & `aliases` in `CreateIndexRequest`